### PR TITLE
Voice2json

### DIFF
--- a/DragonbornSpeaksNaturally.SAMPLE-zhCN.ini
+++ b/DragonbornSpeaksNaturally.SAMPLE-zhCN.ini
@@ -37,6 +37,9 @@
 Engine=Microsoft
 ;Engine=Voice2Json
 
+;;; 通过取消注释（删除开头的分号）为Voice2Json使用bash（wsl）设置而不是docker（默认）
+;bVoice2JsonUseDocker=0
+
 ;;; 语音识别使用的语言，通常不需要设置，使用系统默认语言
 ;;; 如果要手动设置语言，请移除“Locale”前面的分号（;）。
 ;;;
@@ -45,7 +48,7 @@ Engine=Microsoft
 ;;;     zh-cn, zh-tw, zh-hk, zh-sg
 ;;;
 ;;; Engine=Voice2Json 可用的语言：
-;;;     ca-es, cs-cz, de, el-gr, en, en-in, en-us, es, es-mexican, 
+;;;     ca-es, cs-cz, de, el-gr, en, en-in, en-us, es, es-mexican,
 ;;;     fr, hi, it, ko-kr, kz, nl, pl, pt-br, ru, sv, vi, zh, zh-cn
 ;;; 参考文档：http://voice2json.org/#supported-languages
 ;;;
@@ -123,7 +126,7 @@ omitHandSuffix=0
 ;;; 该选项允许你按类别装备收藏夹内物品。
 ;;; 类别是物品名称的一部分 (比如 "铁匕首" 和 "钢匕首" 都属于 "匕首")。
 ;;; 如果有多个物品属于同一类别，第一个物品会被装备。
-;;; 
+;;;
 ;;; 提示:
 ;;;    1. 把等号后面的内容删空就可以禁用该功能。
 ;;;    2. 如果遇到随机装备物品的问题，可以考虑禁用该功能。
@@ -192,7 +195,7 @@ SubsetMatchingMode=None
 ;;; [自定义命令]
 ;;; 请不要修改、删除或者移动下面那行，它是ini配置节名称，删除后下面的选项就不起作用了！
 [ConsoleCommands]
- 
+
 ;;;
 ;;; 可以添加老滚5支持的控制台命令，格式如下:
 ;;;
@@ -224,12 +227,12 @@ SubsetMatchingMode=None
 ;我需要治疗=player.equipspell 12fcc left; player.equipspell 12fcc right; player.cast 12fcc player left; player.cast 12fcc player right
 ;我需要快速治疗=player.equipspell 0002f3b8 left; player.equipspell 0002f3b8 right; player.cast 0002f3b8 player left; player.cast 0002f3b8 player right
 
-;;; 
+;;;
 ;;; 以下命令用于直接施放龙吼
-;;; 
+;;;
 ;;; 你可以从以下页面的子页面找到命令所需的龙吼法术ID:
 ;;;    https://en.uesp.net/wiki/Skyrim:Dragon_Shouts
-;;; 
+;;;
 ;;; 注意，龙吼名称下方的ID不是其法术ID，而是龙吼本身的id，只能与 equipitem 命令一起使用，不能用于 cast 命令。
 ;;; 必须单击龙吼名称进入子页面，然后复制右侧表格里 Spell ID 下面的值。一个龙吼通常对应三个法术ID，对应1到3个力量之语。
 ;;;

--- a/DragonbornSpeaksNaturally.SAMPLE.ini
+++ b/DragonbornSpeaksNaturally.SAMPLE.ini
@@ -36,6 +36,9 @@
 ;Engine=Microsoft
 Engine=Voice2Json
 
+;;; Uncomment (remove leading semicolon) to use bash (wsl) setup for Voice2Json instead of docker (default)
+;bVoice2JsonUseDocker=0
+
 ;;; Set this to override your system's default locale
 ;;;
 ;;; Available Locales for Engine=Microsoft:
@@ -43,7 +46,7 @@ Engine=Voice2Json
 ;;;     zh-cn, zh-tw, zh-hk, zh-sg
 ;;;
 ;;; Available Locales for Engine=Voice2Json:
-;;;     ca-es, cs-cz, de, el-gr, en, en-in, en-us, es, es-mexican, 
+;;;     ca-es, cs-cz, de, el-gr, en, en-in, en-us, es, es-mexican,
 ;;;     fr, hi, it, ko-kr, kz, nl, pl, pt-br, ru, sv, vi, zh, zh-cn
 ;;; References: http://voice2json.org/#supported-languages
 ;;;
@@ -109,15 +112,15 @@ enabled=0
 
 ;;; Set this to your preferred prefix for equipping items.
 ;;; Separate multiple words with semicolons.
-;;; 
+;;;
 ;;; Tips:
 ;;;     If you are struggling with uncontrolled random items equipping in your game,
-;;;     try set a more complicated prefix. 
+;;;     try set a more complicated prefix.
 equipPhrasePrefix=equip;wear;use
 
 ;;; Set to 1 to allow omission of equipPhrasePrefix,
 ;;; which allows you to directly name the equipment to equip the item.
-;;; 
+;;;
 ;;; Note: Enabling this option can greatly increase the probability of false matches.
 ;;;       DSN may equip items randomly due to noise.
 omitHandSuffix=0
@@ -125,7 +128,7 @@ omitHandSuffix=0
 ;;; This setting allows you to equip an item with it's type.
 ;;; Type is a part of the item name (such as "Dagger" for "Iron Dagger" and "Steel Dagger").
 ;;; If multiple items have the same type, the first will be equipped.
-;;; 
+;;;
 ;;; Tips:
 ;;;    1. Remove all items below to disable this feature.
 ;;;    2. If you are struggling with uncontrolled random items equipping in your game, try to disable it.
@@ -223,12 +226,12 @@ SubsetMatchingMode=None
 ;I need treatment=player.equipspell 12fcc left; player.equipspell 12fcc right; player.cast 12fcc player left; player.cast 12fcc player right
 ;I need quick treatment!=player.equipspell 0002f3b8 left; player.equipspell 0002f3b8 right; player.cast 0002f3b8 player left; player.cast 0002f3b8 player right
 
-;;; 
+;;;
 ;;; For a shout's command phrase, use a similar English spelling to improve the recognition rate.
-;;; 
+;;;
 ;;; You can find more shouts' spell ID from the subpage of the page:
 ;;;    https://en.uesp.net/wiki/Skyrim:Dragon_Shouts
-;;; 
+;;;
 ;;; Note that the ID below the shout name is not its spell ID and
 ;;; can only be used with the equipitem command and not for the cast command.
 ;;; You must click the shout name to go to the subpage and copy the value under the "Spell ID" title.

--- a/dsn_service/dsn_service/Voice2JsonCli.cs
+++ b/dsn_service/dsn_service/Voice2JsonCli.cs
@@ -56,7 +56,7 @@ namespace DSN
         }
 
         private int runCommand(string command, string args = "", int waitMs = 0, bool elevating = false) {
-             lock (ioLock) {
+            lock (ioLock) {
                 process = new Process();
                 process.StartInfo.FileName = command;
                 process.StartInfo.Arguments = args;
@@ -72,17 +72,16 @@ namespace DSN
                     process.StartInfo.StandardErrorEncoding = System.Text.Encoding.UTF8;
                 }
 
-                Trace.TraceInformation("Executing: {0} {1}", command, args);
+                Trace.TraceInformation("Executing:\n> {0} {1}", command, args);
                 bool ok = false;
                 try {
                     ok = process.Start();
                 } catch(Exception e) {
-                    Trace.TraceError(e.Message);
+                    Trace.TraceError(e.Message); // log exception and continue
                 }
                 if (!ok) {
                     endSession();
-                    throw new Exception(String.Format("Voice2Json execution failed, please make sure that wsl (bash) is available and voice2json is installed correctly: {0} {1}",
-                        command, args));
+                    throw new Exception(String.Format(GetExecutionException(), command, args));
                 }
 
                 if (!elevating) {
@@ -105,7 +104,18 @@ namespace DSN
             }
         }
 
-        private void init()
+        private void init() {
+            if (UseDocke()) {
+                initDocker();
+            } else {
+                initBash();
+            }
+        }
+
+        /**
+         * Init voice2json via local bash (wsl)
+         */
+        private void initBash()
         {
             Trace.TraceInformation("Automatically downloading speech recognition model files");
             runCommand("bash",
@@ -120,9 +130,72 @@ namespace DSN
                 30000); // sec timeout
         }
 
+        /**
+         * Init voice2json via docker
+         */
+        private void initDocker() {
+            int exitCode;
+            if (runCommand("docker", "ps -a") != 0) {
+                string dockerDesktopPath = @"C:\Program Files\Docker\Docker";
+                try {
+                    dockerDesktopPath = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Docker Inc.\Docker\1.0",
+                        "AppPath", @"C:\Program Files\Docker\Docker").ToString();
+                } catch {
+                    // ignore
+                }
+                dockerDesktopPath += @"\Docker Desktop.exe";
+
+                Trace.TraceInformation("Launch Docker Desktop");
+                exitCode = runCommand(dockerDesktopPath, "", 5000, true);
+                if (exitCode == 0) {
+                    Trace.TraceInformation("Wait for Docker Desktop to be ready");
+                    for (int i = 1; i < 20; i++) {
+                        if (runCommand("docker", "ps -a") == 0) {
+                            break;
+                        } else {
+                            Thread.Sleep(5000);
+                        }
+                    }
+                } else if (exitCode != 2) {
+                    Trace.TraceError("Failed to launch Docker Desktop, please make sure Docker Desktop is installed on your system.", exitCode);
+                }
+            }
+
+            Trace.TraceInformation("Launch the docker container 'dsn_voice2json'");
+            exitCode = runCommand("docker", "start dsn_voice2json");
+
+            if (exitCode != 0) {
+                Trace.TraceInformation("Create the docker container 'dsn_voice2json'");
+                exitCode = runCommand("docker", "run -dit --name dsn_voice2json --entrypoint /bin/sh synesthesiam/voice2json");
+
+                if (exitCode != 0) {
+                    throw new Exception("The Voice2Json container cannot be created automatically, " +
+                        "try creating it manually with the following command:\n" +
+                        "docker run -dit --name dsn_voice2json --entrypoint /bin/sh synesthesiam/voice2json");
+                }
+            }
+
+            Trace.TraceInformation("Automatically download speech recognition model files");
+            runCommand("docker", "exec dsn_voice2json sh -c \"" +
+                "/usr/lib/voice2json/bin/voice2json -p " + config.GetLocale() + " train-profile; " +
+                "ls /root/.local/share/voice2json | while read d; " +
+                "do " +
+                    "ln -sf /root/sentences.ini /root/.local/share/voice2json/$d/sentences.ini; " +
+                "done" +
+                "\"");
+        }
+
         public void LoadJSGF(string jsgf) {
+            Trace.TraceInformation("Generating sentences.ini file and running training");
+            string command = UseDocke() ? "docker" : "bash";
+            string args = UseDocke()
+                    ? "exec -i dsn_voice2json sh -c \"base64 -id > /root/sentences.ini; " +
+                      "/usr/lib/voice2json/bin/voice2json -p " + config.GetLocale() + " train-profile\""
+                    : "-c \"" +
+                      "base64 -id > ~/.dsn_sentences.ini; " +
+                      "voice2json -p " + config.GetLocale() + " train-profile" +
+                      "\"";
             lock (ioLock) {
-                Trace.TraceInformation("Generating sentences.ini file and running training");
                 process = new Process();
                 process.StartInfo.RedirectStandardInput = true;
                 process.StartInfo.RedirectStandardOutput = true;
@@ -130,18 +203,14 @@ namespace DSN
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.StandardOutputEncoding = System.Text.Encoding.UTF8;
                 process.StartInfo.StandardErrorEncoding = System.Text.Encoding.UTF8;
-                process.StartInfo.FileName = "bash";
-                process.StartInfo.Arguments = "-c \""
-                    + "base64 -id > ~/.dsn_sentences.ini; "
-                    + "voice2json -p " + config.GetLocale() + " train-profile"
-                    + "\"";
+                process.StartInfo.FileName = command;
+                process.StartInfo.Arguments = args;
 
-                Trace.TraceInformation("Executing: {0} {1}", process.StartInfo.FileName, process.StartInfo.Arguments);
+                Trace.TraceInformation("Executing: {0} {1}", command, args);
 
                 if (!process.Start()) {
                     endSession();
-                    throw new Exception(String.Format("Voice2Json execution failed, please make sure that bash (wsl) is available and voice2json is installed correctly: {0} {1}",
-                        process.StartInfo.FileName, process.StartInfo.Arguments));
+                    String.Format(String.Format(GetExecutionException() + ":\n> {0} {1}", command, args));
                 }
 
                 readStdOut = new Thread(ReadStdOut);
@@ -158,8 +227,7 @@ namespace DSN
                 endSession();
 
                 if (exitCode != 0) {
-                    throw new Exception(String.Format("Voice2Json execution failed, please make sure that bash (wsl) is available and voice2json is installed correctly: {0} {1}",
-                        process.StartInfo.FileName, process.StartInfo.Arguments));
+                    String.Format(String.Format(GetExecutionException() + ":\n> {0} {1}", command, args));
                 }
             }
         }
@@ -211,6 +279,15 @@ namespace DSN
         }
 
         public void RecognizeAsync() {
+            string command = UseDocke() ? "docker" : "bash";
+            // TODO consolidate
+            string args = UseDocke()
+                    ? "exec -i dsn_voice2json sh -c \"base64 -id | /usr/lib/voice2json/bin/voice2json -p " +
+                      config.GetLocale() + " transcribe-stream --audio-source -" +
+                      " | /usr/lib/voice2json/bin/voice2json -p " + config.GetLocale() + " recognize-intent\""
+                    : "-c \"base64 -id | voice2json -p " +
+                      config.GetLocale() + " transcribe-stream --audio-source -" +
+                      " | voice2json -p " + config.GetLocale() + " recognize-intent\"";
             lock (ioLock) {
                 process = new Process();
                 process.StartInfo.RedirectStandardInput = true;
@@ -219,16 +296,13 @@ namespace DSN
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.StandardOutputEncoding = System.Text.Encoding.UTF8;
                 process.StartInfo.StandardErrorEncoding = System.Text.Encoding.UTF8;
-                process.StartInfo.FileName = "bash";
-                process.StartInfo.Arguments = "-c \"base64 -id | voice2json -p "
-                    + config.GetLocale() + " transcribe-stream --audio-source -"
-                    + " | voice2json -p " + config.GetLocale() + " recognize-intent\"";
+                process.StartInfo.FileName = command;
+                process.StartInfo.Arguments = args;
                 Trace.TraceInformation("Executing: {0} {1}", process.StartInfo.FileName, process.StartInfo.Arguments);
 
                 if (!process.Start()) {
                     endSession();
-                    throw new Exception(String.Format("Voice2Json execution failed, please make sure that bash (wsl) is available and voice2json is installed correctly: {0} {1}",
-                        process.StartInfo.FileName, process.StartInfo.Arguments));
+                    throw new Exception(String.Format(GetExecutionException() + ":\n> {0} {1}", command, args));
                 }
 
                 stdIn = process.StandardInput;
@@ -238,6 +312,7 @@ namespace DSN
                 readStdErr.Start();
             }
         }
+
         private void WaveSourceDataAvailable(object sender, WaveInEventArgs e) {
             //Trace.TraceInformation("WaveSourceDataAvailable: {0}, {1}", sessionId, e.BytesRecorded);
             lock (ioLock) {
@@ -249,6 +324,15 @@ namespace DSN
 
         private string Base64Encode(byte[] buffer) {
             return System.Convert.ToBase64String(buffer);
+        }
+
+        private string GetExecutionException() {
+            return UseDocke() ? "Run docker commnad failed, make sure you have Docker Desktop installed"
+                    : "Voice2Json execution failed, please make sure that bash (wsl) is available and voice2json is installed correctly";
+        }
+
+        private bool UseDocke() {
+            return config.Get("SpeechRecognition", "bVoice2JsonUseDocker", "1") == "1";
         }
     }
 }

--- a/dsn_service/dsn_service/Voice2JsonSpeechRecognition.cs
+++ b/dsn_service/dsn_service/Voice2JsonSpeechRecognition.cs
@@ -295,7 +295,7 @@ namespace DSN {
             }
             string text = result.text;
             string intent = result.intent.name;
-            float confidence = result.intent.confidence * 100;
+            float confidence = result.intent.confidence;
 
             if (logAudioSignalIssues) {
                 Trace.TraceInformation("Recognition log: '{0}' (Confidence: {1})", text, confidence);


### PR DESCRIPTION
A quick hack to get the new voice2json engine running on a cloud machine that doesn't support Docker (no virtualization, meaning no wsl2/hyper-v docker setup possible).

Not sure if my usecase is a rare corner case, but maybe a final version could support this scenario somehow. The setup is rather simple, assuming a (default bash) WSL1 ubuntu installation exists.

    wget https://github.com/synesthesiam/voice2json/releases/download/v2.1/voice2json_2.1_amd64.deb
    sudo apt install ./voice2json_2.1_amd64.deb
    wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
    sudo apt install ./libffi6_3.2.1-8_amd64.deb

I added a config parameter to switch between docker and bash mode. I didn't test the docker scenario but it should work as before and its still the default if not specifically disabled.